### PR TITLE
Add H2 in-memory database configuration

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,27 @@
+# Port
+server:
+    port: 8090
+
+# Application Name
 spring:
     application:
         name: loan-service
+
+    # DataSource configuration for connecting to H2 in-memory database
+    datasource:
+        url: jdbc:h2:mem:testdb
+        driverClassName: org.h2.Driver
+        username: sa
+        password: ''
+
+    # H2 Console configuration for enabling access to H2 database console
+    h2:
+        console:
+            enabled: true
+
+    # JPA configuration for Hibernate
+    jpa:
+        database-platform: org.hibernate.dialect.H2Dialect
+        hibernate:
+            ddl-auto: update
+        show-sql: true


### PR DESCRIPTION
### Description:
This pull request introduces the configuration for integrating H2 in-memory database into the project.

### Changes:
- **Add H2 in-memory database configuration:** Set the application server port to 8090, configure datasource properties for connecting to an H2 in-memory database, enable the H2 console for accessing the database console, and configure JPA/Hibernate properties for the H2 database, including setting the database platform and enabling SQL logging.

### Purpose:
The purpose of this pull request is to set up the necessary configurations for integrating H2 in-memory database into the project, allowing for local development and testing of database-related functionalities.
