### PR TITLE
Add Loan entity, LoanDto, and LoanRepository

### DIFF
--- a/src/main/java/org/example/loanservice/dto/LoanDto.java
+++ b/src/main/java/org/example/loanservice/dto/LoanDto.java
@@ -1,0 +1,13 @@
+package org.example.loanservice.dto;
+
+import java.math.BigDecimal;
+
+public record LoanDto(
+        String mobileNumber,
+        Long loanNumber,
+        String loanType,
+        BigDecimal totalLoan,
+        BigDecimal amountPaid,
+        BigDecimal amountOutstanding
+) {
+}

--- a/src/main/java/org/example/loanservice/entity/Loan.java
+++ b/src/main/java/org/example/loanservice/entity/Loan.java
@@ -1,0 +1,36 @@
+package org.example.loanservice.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.math.BigDecimal;
+
+@Entity
+@Getter
+@Setter
+@ToString
+@AllArgsConstructor
+@NoArgsConstructor
+public class Loan extends Audit {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(nullable = false, length = 15)
+  private String mobileNumber;
+
+  @Column(nullable = false, length = 100)
+  private Long loanNumber;
+
+  @Column(nullable = false, length = 100)
+  private String loanType;
+
+  @Column(nullable = false)
+  private BigDecimal totalLoan;
+
+  @Column(nullable = false)
+  private BigDecimal amountPaid;
+
+  @Column(nullable = false)
+  private BigDecimal amountOutstanding;
+}

--- a/src/main/java/org/example/loanservice/repository/LoanRepository.java
+++ b/src/main/java/org/example/loanservice/repository/LoanRepository.java
@@ -1,0 +1,7 @@
+package org.example.loanservice.repository;
+
+import org.example.loanservice.entity.Loan;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LoanRepository extends JpaRepository<Loan, Long> {
+}


### PR DESCRIPTION
### Description:
This pull request introduces the `Loan` entity, `LoanDto`, and `LoanRepository` to the loan-service module, laying the foundation for managing loan-related data and operations.

### Changes:
- **Add Loan entity:** Added a new `Loan` entity class that extends the `Audit` class, representing the loan data stored in the `loans` table. The entity includes fields such as `mobileNumber`, `loanNumber`, `loanType`, `totalLoan`, `amountPaid`, and `amountOutstanding`.
- **Add LoanDto:** Added a new `LoanDto` record class to serve as the data transfer object for loan data. The `LoanDto` contains the same fields as the `Loan` entity but with different data types, such as `BigDecimal` for monetary values, to facilitate data transfer between the application and external systems.
- **Add LoanRepository:** Added a new `LoanRepository` interface that extends `JpaRepository` to provide an abstraction layer for performing CRUD operations on the `Loan` entity.

### Purpose:
The purpose of this pull request is to establish the core components required for managing loan data within the loan-service module. By introducing the `Loan` entity, the application can persist and retrieve loan-related information from the database. The `LoanDto` facilitates data exchange with external systems or clients, while the `LoanRepository` provides a convenient way to interact with the `Loan` entity through the Spring Data JPA repository abstraction. These components lay the groundwork for implementing loan-related business logic and functionalities within the loan-service module.