### PR TITLE
Add JPA auditing with Spring Data

### DIFF
--- a/src/main/java/org/example/loanservice/LoanServiceApplication.java
+++ b/src/main/java/org/example/loanservice/LoanServiceApplication.java
@@ -2,8 +2,10 @@ package org.example.loanservice;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class LoanServiceApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/org/example/loanservice/audit/AuditorAwareImpl.java
+++ b/src/main/java/org/example/loanservice/audit/AuditorAwareImpl.java
@@ -1,0 +1,16 @@
+package org.example.loanservice.audit;
+
+import lombok.NonNull;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+@Component(value = "auditorAwareImpl")
+public class AuditorAwareImpl implements AuditorAware<String> {
+  @Override
+  @NonNull
+  public Optional<String> getCurrentAuditor() {
+    return Optional.of("loan");
+  }
+}

--- a/src/main/java/org/example/loanservice/entity/Audit.java
+++ b/src/main/java/org/example/loanservice/entity/Audit.java
@@ -1,6 +1,7 @@
 package org.example.loanservice.entity;
 
 import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
 import lombok.Getter;
 import lombok.Setter;
@@ -9,10 +10,12 @@ import org.springframework.data.annotation.CreatedBy;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedBy;
 import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 
 @MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
 @Getter
 @Setter
 @ToString


### PR DESCRIPTION
### Description:
This pull request introduces JPA auditing capabilities to the loan-service module using Spring Data JPA auditing features.

### Changes:
- **Enable JPA auditing:** Added the `@EnableJpaAuditing` annotation to the `LoanServiceApplication` class to enable JPA auditing in the application.
- **Add AuditorAwareImpl:** Added an `AuditorAwareImpl` class that implements the `AuditorAware` interface to provide the current auditor value (e.g., "loan") for auditing purposes.
- **Modify Audit entity:** Modified the `Audit` entity class to include the `@EntityListeners(AuditingEntityListener.class)` annotation, which enables auditing for entities that extend the `Audit` class.

### Purpose:
The purpose of this pull request is to implement auditing functionality in the loan-service module, which tracks and records information about who created or modified an entity and when the changes were made.